### PR TITLE
Removes dependecy on Medea

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,15 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "Medea",
-        "repositoryURL": "https://github.com/jemmons/Medea.git",
-        "state": {
-          "branch": null,
-          "revision": "806bfb36c4f1e12b365c8b4108a834f35a614c44",
-          "version": "5.0.0"
-        }
-      },
-      {
         "package": "swift-nio",
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -14,14 +14,13 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.8.0"),
-        .package(url: "https://github.com/jemmons/Medea.git", from: "5.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Perfidy",
-            dependencies: ["NIO", "NIOHTTP1", "Medea"]),
+            dependencies: ["NIO", "NIOHTTP1"]),
         .testTarget(
             name: "PerfidyTests",
             dependencies: ["Perfidy"]),

--- a/Sources/Perfidy/Types.swift
+++ b/Sources/Perfidy/Types.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+
+public typealias JSONObject = [String: Any]
+public typealias JSONArray = [Any]

--- a/Tests/PerfidyTests/FromFileTests.swift
+++ b/Tests/PerfidyTests/FromFileTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import Perfidy
-import Medea
 
 
 
@@ -27,8 +26,8 @@ class FromFileTests: XCTestCase {
     session.resumeRequest("GET", "/api/account/111") { data, res, err in
       XCTAssertNil(err)
       XCTAssertEqual(res?.statusCode, 200)
-      let json = try! JSONHelper.jsonObject(from: data!)
-      XCTAssertEqual(json as! [String: String], K.account)
+      let json = try! JSONDecoder().decode([String: String].self, from: data!)
+      XCTAssertEqual(json, K.account)
       expectedGETResponse.fulfill()
     }
     
@@ -36,8 +35,8 @@ class FromFileTests: XCTestCase {
     session.resumeRequest("POST", "/api/account") { data, res, err in
       XCTAssertNil(err)
       XCTAssertEqual(res?.statusCode, 201)
-      let json = try! JSONHelper.jsonObject(from: data!)
-      XCTAssertEqual(json as! [String: String], K.account)
+      let json = try! JSONDecoder().decode([String: String].self, from: data!)
+      XCTAssertEqual(json, K.account)
       expectedPOSTResponse.fulfill()
     }
 

--- a/Tests/PerfidyTests/ServerTests.swift
+++ b/Tests/PerfidyTests/ServerTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import Perfidy
-import Medea
+
+
 
 class ServerTests: XCTestCase {
   func testTimeout() {
@@ -151,8 +152,8 @@ class ServerTests: XCTestCase {
       
       session.resumeRequest("GET", "/path") { data, res, _ in
         XCTAssertEqual(res?.statusCode, 201)
-        let json = try! JSONHelper.jsonObject(from: data!)
-        XCTAssertEqual(json["thing"] as! NSNumber, 42)
+        let json = try! JSONDecoder().decode([String: Int].self, from: data!)
+        XCTAssertEqual(json["thing"], 42)
         expectedResponse.fulfill()
       }
 
@@ -170,8 +171,8 @@ class ServerTests: XCTestCase {
 
       session.resumeRequest("GET", "/path") { data, res, _ in
         XCTAssertEqual(res!.statusCode, 202)
-        let json = try! JSONHelper.jsonObject(from: data!)
-        XCTAssertEqual(json["fred"] as! String, "barney")
+        let json = try! JSONDecoder().decode([String: String].self, from: data!)
+        XCTAssertEqual(json["fred"], "barney")
         expectedResponse.fulfill()
       }
 
@@ -189,8 +190,8 @@ class ServerTests: XCTestCase {
 
       session.resumeRequest("GET", "/some/path") { data, res, _ in
         XCTAssertEqual(res!.statusCode, 203)
-        let json = try! JSONHelper.jsonArray(from: data!)
-        XCTAssertEqual(json as! [String], ["fred","barney"])
+        let json = try! JSONDecoder().decode([String].self, from: data!)
+        XCTAssertEqual(json, ["fred","barney"])
         expectResponse.fulfill()
       }
 
@@ -209,7 +210,7 @@ class ServerTests: XCTestCase {
         expectReceived.fulfill()
       }
 
-      let data = try! JSONHelper.data(from: ValidJSONObject(["foo": "bar"]))
+      let data = try! JSONEncoder().encode(["foo": "bar"])
       session.resumeRequest("POST", "/", body: data) { _, _, _ in
         expectSent.fulfill()
       }


### PR DESCRIPTION
Some of Medea is now done better with codable. Some of it is unnecessary becasue of improvements to Swift. Of the rest (mostly around validation), there's just not enough to justify a dependency.

Though everything should still work, this is technically a breaking change as `JSONObject` and `JSONArray` types and various errors are now in the `Perfidy` namespace.