### PR TITLE
Makes `start` implicit with initialization.

### DIFF
--- a/Tests/PerfidyTests/FromFileTests.swift
+++ b/Tests/PerfidyTests/FromFileTests.swift
@@ -12,12 +12,10 @@ private enum K {
 
 
 class FromFileTests: XCTestCase {
-  
-  func testMockInterface() {
-    let server = FakeServer()
-    try! server.add(fromFileName: "mockinterface", bundle: fetchFakeBundle())
-    try! server.start()
+  func testMockInterface() throws {
+    let server = try FakeServer()
     defer { server.stop() }
+    try server.add(fromFileName: "mockinterface", bundle: fetchFakeBundle())
     
     let expectedGETResponse = expectation(description: "Waiting for GET response")
     let expectedPOSTResponse = expectation(description: "Waiting for POST response")
@@ -48,7 +46,7 @@ class FromFileTests: XCTestCase {
       expectedPUTResponse.fulfill()
     }
     
-    wait(for: [expectedGETResponse, expectedPOSTResponse, expectedPUTResponse], timeout: 1)
+    wait(for: [expectedGETResponse, expectedPOSTResponse, expectedPUTResponse], timeout: 10)
   }
 }
 

--- a/Tests/PerfidyTests/RequestTrackingTests.swift
+++ b/Tests/PerfidyTests/RequestTrackingTests.swift
@@ -5,46 +5,46 @@ import Perfidy
 
 
 class RequestTrackingTests: XCTestCase {
-  func testRequestWasSent() {
+  func testRequestWasSent() throws {
     let responseReceived = expectation(description: "Waiting for response")
     let route: Route = "PUT /hello"
     
-    FakeServer.runWith { server in
-      server.add(route)
+    let server = try FakeServer()
+    defer { server.stop() }
+    server.add(route)
 
-      XCTAssertFalse(server.didRequest(route: route))
+    XCTAssertFalse(server.didRequest(route: route))
       
-      session.resumeRequest("PUT", "/hello") { _, _, _ in
-        XCTAssert(server.didRequest(route: route))
-        responseReceived.fulfill()
-      }
-      wait(for: [responseReceived], timeout: 1)
+    session.resumeRequest("PUT", "/hello") { _, _, _ in
+      XCTAssert(server.didRequest(route: route))
+      responseReceived.fulfill()
     }
+    wait(for: [responseReceived], timeout: 1)
   }
   
   
-  func testRequestWasSentTwice() {
+  func testRequestWasSentTwice() throws {
     let responseReceived = expectation(description: "Waiting for responses")
     responseReceived.expectedFulfillmentCount = 2
     
     let route: Route = "POST /content/111"
     
-    FakeServer.runWith { server in
-      server.add(route)
+    let server = try FakeServer()
+    defer { server.stop() }
+    server.add(route)
 
-      XCTAssertEqual(server.numberOfRequests(for: route), 0)
+    XCTAssertEqual(server.numberOfRequests(for: route), 0)
       
-      session.resumeRequest("POST", "/content/111") { _, _, _ in
-        responseReceived.fulfill()
-      }
+    session.resumeRequest("POST", "/content/111") { _, _, _ in
+      responseReceived.fulfill()
+    }
       
-      session.resumeRequest("POST", "/content/111") { _, _, _ in
-        responseReceived.fulfill()
-      }
+    session.resumeRequest("POST", "/content/111") { _, _, _ in
+      responseReceived.fulfill()
+    }
       
-      waitForExpectations(timeout: 1) { _ in
-        XCTAssertEqual(server.numberOfRequests(for: route), 2)
-      }
+    waitForExpectations(timeout: 1) { _ in
+      XCTAssertEqual(server.numberOfRequests(for: route), 2)
     }
   }
 }

--- a/Tests/PerfidyTests/ResponseTests.swift
+++ b/Tests/PerfidyTests/ResponseTests.swift
@@ -26,8 +26,8 @@ class ResponseTests : XCTestCase{
   }
   
   
-  func testRawJSON() {
-    let subject = try! Response(rawJSON: "{\"foo\":\"bar\"}")
+  func testRawJSON() throws {
+    let subject = try Response(rawJSON: "{\"foo\":\"bar\"}")
     XCTAssertEqual(String(data: subject.body!, encoding: String.Encoding.utf8), "{\"foo\":\"bar\"}")
     XCTAssertEqual(subject.headers[lengthKey], "13")
     XCTAssertEqual(subject.headers[typeKey], "application/json")
@@ -51,16 +51,16 @@ class ResponseTests : XCTestCase{
   }
   
   
-  func testJSONObject() {
-    let subject = try! Response(jsonObject: ["foo":"bar"])
+  func testJSONObject() throws {
+    let subject = try Response(jsonObject: ["foo":"bar"])
     XCTAssertEqual(String(data: subject.body!, encoding: .utf8), "{\"foo\":\"bar\"}")
     XCTAssertEqual(subject.headers[lengthKey], "13")
     XCTAssertEqual(subject.headers[typeKey], "application/json")
   }
   
   
-  func testJSONArray() {
-    let subject = try! Response(jsonArray: [1,2,3])
+  func testJSONArray() throws {
+    let subject = try Response(jsonArray: [1,2,3])
     XCTAssertEqual(String(data: subject.body!, encoding: .utf8), "[1,2,3]")
     XCTAssertEqual(subject.headers[lengthKey], "7")
     XCTAssertEqual(subject.headers[typeKey], "application/json")

--- a/Tests/PerfidyTests/ServerTests.swift
+++ b/Tests/PerfidyTests/ServerTests.swift
@@ -4,219 +4,225 @@ import Perfidy
 
 
 class ServerTests: XCTestCase {
-  func testTimeout() {
+  func testTimeout() throws {
     let config = URLSessionConfiguration.default
     config.timeoutIntervalForRequest = 1.0
     let quickTimeoutSession = URLSession(configuration: config)
     
     let shouldTimeOut = expectation(description: "times out")
     
-    FakeServer.runWith { server in
-      server.add("/", response: 666)
+    let server = try FakeServer()
+    defer { server.stop() }
+    server.add("/", response: 666)
       
-      quickTimeoutSession.resumeRequest("GET", "/") { _, _, error in
-        guard let someError = error as NSError? else {
-          XCTFail()
-          return
-        }
-        XCTAssertEqual(someError.code, URLError.timedOut.rawValue)
-        XCTAssertEqual(someError.domain, URLError.errorDomain)
-        shouldTimeOut.fulfill()
+    quickTimeoutSession.resumeRequest("GET", "/") { _, _, error in
+      guard let someError = error as NSError? else {
+        XCTFail()
+        return
       }
-      
-      wait(for: [shouldTimeOut], timeout: 2)
+      XCTAssertEqual(someError.code, URLError.timedOut.rawValue)
+      XCTAssertEqual(someError.domain, URLError.errorDomain)
+      shouldTimeOut.fulfill()
     }
+    
+    wait(for: [shouldTimeOut], timeout: 2)
   }
   
 
-  func testDefaultShouldConnect(){
+  func testDefaultShouldConnect() throws {
     let expectResponse = expectation(description: "Response received.")
-    FakeServer.runWith { _ in
-      session.resumeRequest("GET", "/") { data, res, error in
-        XCTAssertEqual(res!.statusCode, 404)
-        expectResponse.fulfill()
-      }
-      wait(for: [expectResponse], timeout: 1)
+    let server = try FakeServer()
+    defer { server.stop() }
+    session.resumeRequest("GET", "/") { data, res, error in
+      XCTAssertEqual(res!.statusCode, 404)
+      expectResponse.fulfill()
     }
+    wait(for: [expectResponse], timeout: 1)
   }
 
 
-  func testShouldErrorOnDuplicateConnections(){
+  func testShouldErrorOnDuplicateConnections() throws {
     let shouldThrow = expectation(description: "Should throw")
-    FakeServer.runWith { server in
-      do {
-        try server.start()
-      } catch NetworkError.portAlreadyInUse(let port) {
-        XCTAssertEqual(port, 10175)
-        shouldThrow.fulfill()
-      } catch {
-        XCTFail()
-      }
-      wait(for: [shouldThrow], timeout: 2)
+    let server = try FakeServer()
+    defer { server.stop() }
+    do {
+      let otherServer = try FakeServer()
+    } catch NetworkError.portAlreadyInUse(let port) {
+      XCTAssertEqual(port, 10175)
+      shouldThrow.fulfill()
+    } catch {
+      XCTFail()
     }
+    wait(for: [shouldThrow], timeout: 2)
   }
 
 
-  func testStatusCodes(){
+  func testStatusCodes() throws {
     let expect201 = expectation(description: "201 status code")
     let expect300 = expectation(description: "300 status code")
     let expect400 = expectation(description: "400 status code")
     let expect800 = expectation(description: "Nonexistant status code")
 
-    FakeServer.runWith { server in
-      server.add("/201", response: 201)
-      server.add("/300", response: 300)
-      server.add("/400", response: 400)
-      server.add("/800", response: 800)
+    let server = try FakeServer()
+    defer { server.stop() }
+    server.add("/201", response: 201)
+    server.add("/300", response: 300)
+    server.add("/400", response: 400)
+    server.add("/800", response: 800)
 
-      session.resumeRequest("GET", "/201") { _, res, _ in
-        XCTAssertEqual(res!.statusCode, 201)
-        expect201.fulfill()
-      }
-
-      session.resumeRequest("GET", "/300") { _, res, _ in
-        XCTAssertEqual(res!.statusCode, 300)
-        expect300.fulfill()
-      }
-
-      session.resumeRequest("GET", "/400") { _, res, _ in
-        XCTAssertEqual(res!.statusCode, 400)
-        expect400.fulfill()
-      }
-
-      
-      session.resumeRequest("GET", "/800") { _, res, _ in
-        XCTAssertEqual(res!.statusCode, 800)
-        expect800.fulfill()
-      }
-      
-      wait(for: [expect201, expect300, expect400, expect800], timeout: 1)
+    session.resumeRequest("GET", "/201") { _, res, _ in
+      XCTAssertEqual(res!.statusCode, 201)
+      expect201.fulfill()
     }
+    
+    session.resumeRequest("GET", "/300") { _, res, _ in
+      XCTAssertEqual(res!.statusCode, 300)
+      expect300.fulfill()
+    }
+    
+    session.resumeRequest("GET", "/400") { _, res, _ in
+      XCTAssertEqual(res!.statusCode, 400)
+      expect400.fulfill()
+    }
+
+      
+    session.resumeRequest("GET", "/800") { _, res, _ in
+      XCTAssertEqual(res!.statusCode, 800)
+      expect800.fulfill()
+    }
+    
+    wait(for: [expect201, expect300, expect400, expect800], timeout: 1)
   }
 
   
   
-  func testSetDefaultStatusCode(){
+  func testSetDefaultStatusCode() throws {
     let shouldBurn = expectation(description: "should implicitly return `defaultStatusCode` when no response given")
     
-    FakeServer.runWith(defaultStatusCode: 541) { server in
-      session.resumeRequest("GET", "/foo/bar/baz") { _, res, _ in
-        XCTAssertEqual(res!.statusCode, 541)
-        shouldBurn.fulfill()
-      }
-      wait(for: [shouldBurn], timeout: 1)
+    let server = try FakeServer(defaultStatusCode: 541)
+    defer { server.stop() }
+    session.resumeRequest("GET", "/foo/bar/baz") { _, res, _ in
+      XCTAssertEqual(res!.statusCode, 541)
+      shouldBurn.fulfill()
     }
+    wait(for: [shouldBurn], timeout: 1)
   }
 
 
-  func testDefaultStatusCodeOfAddedRoute() {
+  func testDefaultStatusCodeOfAddedRoute() throws {
     let should200 = expectation(description: "routes without status codes are assumed to be 200")
-    FakeServer.runWith { server in
-      server.add("/real/route")
-      session.resumeRequest("GET", "/real/route") { _, res, _ in
-        XCTAssertEqual(res!.statusCode, 200)
-        should200.fulfill()
-      }
-      wait(for: [should200], timeout: 1)
+    let server = try FakeServer()
+    defer { server.stop() }
+    server.add("/real/route")
+    session.resumeRequest("GET", "/real/route") { _, res, _ in
+      XCTAssertEqual(res!.statusCode, 200)
+      should200.fulfill()
     }
+    wait(for: [should200], timeout: 1)
   }
 
 
-  func testHeaders() {
+  func testHeaders() throws {
     let shouldReceive = expectation(description: "receive request with header")
     let shouldRespond = expectation(description: "respond")
 
-    FakeServer.runWith { server in
-      server.add("/", response: 200) { req in
-        XCTAssertEqual(req.value(forHTTPHeaderField: "foo"), "bar")
-        shouldReceive.fulfill()
-      }
-
-      session.resumeRequest("GET", "/", headers: ["foo": "bar"]) { _, res, error in
-        XCTAssertNil(error)
-        XCTAssertEqual(res!.statusCode, 200)
-        shouldRespond.fulfill()
-      }
-
-      wait(for: [shouldReceive, shouldRespond], timeout: 1)
+    let server = try FakeServer()
+    defer { server.stop() }
+    server.add("/", response: 200) { req in
+      XCTAssertEqual(req.value(forHTTPHeaderField: "foo"), "bar")
+      shouldReceive.fulfill()
     }
+
+    session.resumeRequest("GET", "/", headers: ["foo": "bar"]) { _, res, error in
+      XCTAssertNil(error)
+      XCTAssertEqual(res!.statusCode, 200)
+      shouldRespond.fulfill()
+    }
+    
+    wait(for: [shouldReceive, shouldRespond], timeout: 1)
   }
 
 
-  func testRawJSONResponse(){
+  func testRawJSONResponse() throws {
     let expectedResponse = expectation(description: "Should get response")
 
-    FakeServer.runWith { server in
-      server.add("/path",
-                 response: try! Response(status: 201, rawJSON:"{\"thing\":42}"))
+    let server = try FakeServer()
+    defer { server.stop() }
+    server.add(
+      "/path",
+      response: try Response(status: 201, rawJSON:"{\"thing\":42}")
+    )
       
-      session.resumeRequest("GET", "/path") { data, res, _ in
-        XCTAssertEqual(res?.statusCode, 201)
-        let json = try! JSONDecoder().decode([String: Int].self, from: data!)
-        XCTAssertEqual(json["thing"], 42)
-        expectedResponse.fulfill()
-      }
-
-      wait(for: [expectedResponse], timeout: 1)
+    session.resumeRequest("GET", "/path") { data, res, _ in
+      XCTAssertEqual(res?.statusCode, 201)
+      let json = try! JSONDecoder().decode([String: Int].self, from: data!)
+      XCTAssertEqual(json["thing"], 42)
+      expectedResponse.fulfill()
     }
+
+    wait(for: [expectedResponse], timeout: 1)
   }
 
 
-  func testJSONObjectResponse(){
+  func testJSONObjectResponse() throws {
     let expectedResponse = expectation(description: "Should get response")
 
-    FakeServer.runWith { server in
-      server.add("/path",
-                 response: try! Response(status: 202, jsonObject:["fred":"barney"]))
+    let server = try FakeServer()
+    defer { server.stop() }
+    server.add(
+      "/path",
+      response: try Response(status: 202, jsonObject:["fred":"barney"])
+    )
 
-      session.resumeRequest("GET", "/path") { data, res, _ in
-        XCTAssertEqual(res!.statusCode, 202)
-        let json = try! JSONDecoder().decode([String: String].self, from: data!)
-        XCTAssertEqual(json["fred"], "barney")
-        expectedResponse.fulfill()
-      }
-
-      wait(for: [expectedResponse], timeout: 1)
+    session.resumeRequest("GET", "/path") { data, res, _ in
+      XCTAssertEqual(res!.statusCode, 202)
+      let json = try! JSONDecoder().decode([String: String].self, from: data!)
+      XCTAssertEqual(json["fred"], "barney")
+      expectedResponse.fulfill()
     }
+
+    wait(for: [expectedResponse], timeout: 1)
   }
 
 
-  func testJSONArrayResponse(){
+  func testJSONArrayResponse() throws {
     let expectResponse = expectation(description: "Should get response")
 
-    FakeServer.runWith { server in
-      server.add("/some/path",
-                 response: try! Response(status: 203, jsonArray:["fred","barney"]))
+    let server = try FakeServer()
+    defer { server.stop() }
+    server.add(
+      "/some/path",
+      response: try Response(status: 203, jsonArray:["fred","barney"])
+    )
 
-      session.resumeRequest("GET", "/some/path") { data, res, _ in
-        XCTAssertEqual(res!.statusCode, 203)
-        let json = try! JSONDecoder().decode([String].self, from: data!)
-        XCTAssertEqual(json, ["fred","barney"])
-        expectResponse.fulfill()
-      }
-
-      wait(for: [expectResponse], timeout: 1)
+    session.resumeRequest("GET", "/some/path") { data, res, _ in
+      XCTAssertEqual(res!.statusCode, 203)
+      let json = try! JSONDecoder().decode([String].self, from: data!)
+      XCTAssertEqual(json, ["fred","barney"])
+      expectResponse.fulfill()
     }
+    
+    wait(for: [expectResponse], timeout: 1)
   }
 
 
-  func testPostingData() {
+  func testPostingData() throws {
     let expectSent = expectation(description: "Sent data")
     let expectReceived = expectation(description: "Received data")
 
-    FakeServer.runWith { server in
-      server.add("POST /") { req in
-        XCTAssertEqual(String(data: req.httpBody!, encoding: .utf8), "{\"foo\":\"bar\"}")
-        expectReceived.fulfill()
-      }
-
-      let data = try! JSONEncoder().encode(["foo": "bar"])
-      session.resumeRequest("POST", "/", body: data) { _, _, _ in
-        expectSent.fulfill()
-      }
-
-      wait(for: [expectSent, expectReceived], timeout: 1)
+    let server = try FakeServer()
+    defer { server.stop() }
+    server.add("POST /") { req in
+      XCTAssertEqual(String(data: req.httpBody!, encoding: .utf8), "{\"foo\":\"bar\"}")
+      expectReceived.fulfill()
     }
+
+    let data = try JSONEncoder().encode(["foo": "bar"])
+    session.resumeRequest("POST", "/", body: data) { _, _, _ in
+      expectSent.fulfill()
+    }
+
+    wait(for: [expectSent, expectReceived], timeout: 1)
   }
 
 
@@ -225,34 +231,32 @@ class ServerTests: XCTestCase {
   }
 
 
-  func testFakeServerURL() {
-    FakeServer.runWith(port: 11111) { server in
-      XCTAssertEqual(server.url.absoluteString, "http://localhost:11111")
-    }
+  func testFakeServerURL() throws {
+    let server = try FakeServer(port: 11111)
+    defer { server.stop() }
+    XCTAssertEqual(server.url.absoluteString, "http://localhost:11111")
   }
   
   
-  func testFakeServerListensOnCustomPort() {
+  func testFakeServerListensOnCustomPort() throws {
     let answerOnCustomPort = expectation(description: "should answer on custom port")
-    let defaulPortStillOpen = expectation(description: "default port is still available")
-    FakeServer.runWith(port: 11111, defaultStatusCode: 200) { _ in
-      session.dataTask(with: URL(string: "http://localhost:11111/foo")!) { data, res, error in
-        XCTAssertNil(error)
-        XCTAssertEqual((res as? HTTPURLResponse)?.statusCode, 200)
-        answerOnCustomPort.fulfill()
-        
-        let server = FakeServer()
-        defer { server.stop() }
-        do {
-          try server.start()
-          defaulPortStillOpen.fulfill()
-        } catch {
-          XCTFail()
-        }
-      }.resume()
-      
-      wait(for: [answerOnCustomPort, defaulPortStillOpen], timeout: 1)
-    }
+    let defaulPortFails = expectation(description: "default port is not available")
+    let customServer = try FakeServer(port: 11111, defaultStatusCode: 200)
+    defer { customServer.stop() }
+    session.dataTask(with: URL(string: "http://localhost:11111/foo")!) { data, res, error in
+      XCTAssertNil(error)
+      XCTAssertEqual((res as? HTTPURLResponse)?.statusCode, 200)
+      answerOnCustomPort.fulfill()
+    }.resume()
+
+    session.dataTask(with: URL(string: "http://localhost:10175/foo")!) { data, res, error in
+      XCTAssertNil(data)
+      XCTAssertNil(res)
+      XCTAssert(URLError.cannotConnectToHost ~= error!)
+      defaulPortFails.fulfill()
+    }.resume()
+
+    wait(for: [answerOnCustomPort, defaulPortFails], timeout: 1)
   }
 }
 

--- a/Tests/PerfidyTests/TearDownStyleTests.swift
+++ b/Tests/PerfidyTests/TearDownStyleTests.swift
@@ -4,13 +4,40 @@ import Perfidy
 
 
 class TearDownStyleTests: XCTestCase {
-  let server = FakeServer()
+  var server: FakeServer!
   
+  override func setUp() {
+    server = try! FakeServer()
+  }
   
   override func tearDown() {
     server.stop()
   }
   
+  
+  // Pretend we want to test an app that will fetch a mesasge...
+  func testGetData() {
+    let expectRequestSent = expectation(description: "Should send a request to get the message.")
+    let expectConfirmation = expectation(description: "Should display update confirmation.")
+    
+    // Add the path the app would be fetching from to our fake server.
+    server.add("GET /message/1", response: Response(status: 200, text: "a message")) { request in
+      // This closure will be executed with the response received by the server. Verify the expected properties have been sent by the app here.
+      expectRequestSent.fulfill()
+    }
+        
+    // Do what we have to in our app to fetch the message. For this example, we’re sending a request via `URLSession`.
+    let session = URLSession(configuration: URLSessionConfiguration.default)
+    var req = URLRequest(url: URL(string: "http://localhost:10175/message/1")!)
+    req.httpMethod = "GET"
+    session.dataTask(with: req) { _, _, _ in
+      // Check that the app properly updates its UI after receiving the response from the server.
+      expectConfirmation.fulfill()
+    }.resume()
+    
+    wait(for: [expectRequestSent, expectConfirmation], timeout: 10)
+  }
+
   
   // Pretend we want to test an app that will update a mesasge...
   func testPostData() {
@@ -22,10 +49,7 @@ class TearDownStyleTests: XCTestCase {
       // This closure will be executed with the response received by the server. Verify the expected properties have been sent by the app here.
       expectUpdateRequestSent.fulfill()
     }
-    
-    // Start the fake server.
-    try! server.start()
-    
+        
     // Do what we have to in our app to update the message. For this example, we’re sending a request via `URLSession`.
     let session = URLSession(configuration: URLSessionConfiguration.default)
     var req = URLRequest(url: URL(string: "http://localhost:10175/message/1")!)
@@ -35,6 +59,6 @@ class TearDownStyleTests: XCTestCase {
       expectConfirmation.fulfill()
     }.resume()
     
-    wait(for: [expectUpdateRequestSent, expectConfirmation], timeout: 1)
+    wait(for: [expectUpdateRequestSent, expectConfirmation], timeout: 10)
   }
 }


### PR DESCRIPTION
As commonly used, it was rare to create a `FakeServer` and not immediately `start` it. So this step is now a part of initialization.

It would make sense, then, to `stop` in `deinit`, right? Except that swift tends to favor optimization over predictable object lifespans. Without `withExtendedLifetime` there’s always the chance of the server getting deinit early, and we’ve already seen issues with the `runWith` closure interacting confusingly with asynchronous tests resulting in early termination of the server. Best for everyone to keep `stop` explicit.